### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   release:
@@ -37,4 +39,3 @@ jobs:
       - name: Install dependencies
         run: npm install
       # Test cases coming soon
-


### PR DESCRIPTION
Potential fix for [https://github.com/zanderlewis/wakatime-client-remastered/security/code-scanning/1](https://github.com/zanderlewis/wakatime-client-remastered/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow performs basic CI tasks, the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to the repository contents and does not inadvertently inherit write permissions.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs in the workflow. This avoids redundancy and ensures consistency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
